### PR TITLE
Cleaning console log

### DIFF
--- a/backend/src/app.gateway.ts
+++ b/backend/src/app.gateway.ts
@@ -36,7 +36,6 @@ export class MasterGateway implements OnGatewayConnection, OnGatewayDisconnect {
       }
     }
     catch (e) {
-      console.log("error jwt (connect): ", e)
     }
   }
 
@@ -49,7 +48,6 @@ export class MasterGateway implements OnGatewayConnection, OnGatewayDisconnect {
           secret: process.env.JWTSECRET
         }
       );
-      // console.log('payload: ', payload)
       if (!payload || !payload.sub)
       {
         console.log('in if not payload')
@@ -72,7 +70,6 @@ export class MasterGateway implements OnGatewayConnection, OnGatewayDisconnect {
       }
     }
     catch (e) {
-      console.log("error jwt (disconnect): ", e)
     }
   }
 }

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -38,7 +38,6 @@ export class ChatGateway implements OnGatewayConnection, OnGatewayDisconnect {
 				newSocket.user = (user.id).toString()
 		}
 		catch (e) {
-			console.log("error jwt (connect(chat)): ", e)
 		}
 		if (this.sockets === undefined) {
 			this.sockets = [newSocket]

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -67,7 +67,6 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 			userId = payload.sub
 		}
 		catch (e) {
-			console.log("error jwt (connect(game)): ", e)
 		}
 		const user = await this.prisma.user.findFirst({
 			where: {
@@ -128,7 +127,6 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
 			userId = payload.sub
 		}
 		catch (e) {
-			console.log("error jwt (connect(game)): ", e)
 		}
 		if (!userId)
 			return ;

--- a/frontend/src/components/chat/channels/ChannelButton.tsx
+++ b/frontend/src/components/chat/channels/ChannelButton.tsx
@@ -65,6 +65,7 @@ const ChannelButton: React.FC<ChannelButtonProps> = ({ channel }) => {
 					}
 					else {
 						console.log('successfully joined');
+						channel.joined = true;
 						changeChannel(channel);
 					}
 				})


### PR DESCRIPTION
Removed: useless console.log

Fix: alert message when the user try to rejoin a channel that he just joined without refreshing the page

To test:
- [x] edit access_token cookie, no jwt error should appear in backend logs
- [x] search a channel that you have not joined, and click twice on that channel button, no alert message should appear
